### PR TITLE
Support multi-strategy recompute/offloading configs and add MQA/GQA for Llama model

### DIFF
--- a/docs/activation_recomputation.md
+++ b/docs/activation_recomputation.md
@@ -1,0 +1,45 @@
+# Activation Recomputation (Gradient Checkpointing)
+
+## Introduction
+
+Activation recomputation, also known as gradient checkpointing, is a memory optimization technique that trades off computational overhead for reduced memory consumption during training. It achieves this by discarding intermediate activations during the forward pass and recomputing them during the backward pass.
+
+## Configuration
+
+### recompute_granularity
+Controls the scope of activations to recompute within a Transformer block.
+
+* `selective`: Recomputes only specific submodules (`RMSNorm` and `Swiglu` for Llama) in the Transformer block.
+  - Reduces memory usage for targeted submodules while preserving the rest for memory-speed trade-off
+* `full`: Recomputes all activations in the Transformer block.
+  - Maximizes memory savings at the cost of higher computational overhead.
+* **Default**: Not set (user must explicitly specify).
+
+### recompute_method
+Defines the strategy for partitioning and recomputing Transformer blocks.
+
+* `uniform`: Divides the total number of Transformer blocks into partitions and recomputes contiguous blocks in each partition.
+  - Example: If there are 24 blocks and `recompute_num_layers`=2, each partition will recompute 2 contiguous blocks, preserving the activations of the first block in each partition.
+* `block`: Recomputes the first `recompute_num_layers` individual Transformer blocks in each pipeline stage, leaving the rest untouched.
+* **Default**: Not set (user must explicitly specify).
+
+### recompute_num_layers
+Specifies the number of Transformer blocks to recompute per partition or stage. Interpretation depends on `recompute_method`.
+
+* `uniform`: the number of contiguous Transformer blocks to recompute in each partition
+* `block`: the number of individual Transformer blocks to recompute in each pipeline stage
+* **Default**: 1
+
+### recompute_layer_idxs
+Manually specifies the indices of Transformer blocks to recompute.
+
+* Overrides `recompute_method` and `recompute_num_layers` when set.
+* **Default**: all Transformer blocks.
+
+## Usage Notes
+
+### Compatibility
+
+1. **Selective Recomputation Constraints**: `recompute_granularity=selective` is incompatible with `recompute_method`. Please use `recompute_layer_idxs` to manually specify blocks for selective recomputation.
+
+2. **Parameter Precedence**: If `recompute_layer_idxs` is set, `recompute_method` and `recompute_num_layers` are ignored. 

--- a/examples/lobra/model/llama/llama_model.py
+++ b/examples/lobra/model/llama/llama_model.py
@@ -30,7 +30,10 @@ class LLamaAttention(ht.nn.Module):
 
         self.embed_dim = config.hidden_size
         self.num_heads = config.num_attention_heads
+        self.num_groups = config.num_query_groups
         self.head_dim = self.embed_dim // self.num_heads
+        self.query_projection_size = self.embed_dim
+        self.kv_projection_size = self.num_groups * self.head_dim
         self.split_size = self.embed_dim
         if self.head_dim * self.num_heads != self.embed_dim:
             raise ValueError(
@@ -46,7 +49,7 @@ class LLamaAttention(ht.nn.Module):
 
         self.q_proj = ht.nn.HtMultiColumnParallelLinear(
             self.embed_dim,
-            self.embed_dim,
+            self.query_projection_size,
             get_multi_ds_parallel_config(ds_parallel_configs, 'qkv', layer_idx),
             bias=self.add_bias,
             gather_output=False,
@@ -55,7 +58,7 @@ class LLamaAttention(ht.nn.Module):
 
         self.k_proj = ht.nn.HtMultiColumnParallelLinear(
             self.embed_dim,
-            self.embed_dim,
+            self.kv_projection_size,
             get_multi_ds_parallel_config(ds_parallel_configs, 'qkv', layer_idx),
             bias=self.add_bias,
             gather_output=False,
@@ -64,7 +67,7 @@ class LLamaAttention(ht.nn.Module):
         
         self.v_proj = ht.nn.HtMultiColumnParallelLinear(
             self.embed_dim,
-            self.embed_dim,
+            self.kv_projection_size,
             get_multi_ds_parallel_config(ds_parallel_configs, 'qkv', layer_idx),
             bias=self.add_bias,
             gather_output=False,
@@ -98,8 +101,8 @@ class LLamaAttention(ht.nn.Module):
         v = self.v_proj(hidden_states)
         
         query = q.reshape([mbs_times_dp_symbol, seq_len_symbol, ht.IntSymbol(self.num_heads), ht.IntSymbol(self.head_dim)], name=f'reshape_q_{self.name}')
-        key = k.reshape([mbs_times_dp_symbol, seq_len_symbol, ht.IntSymbol(self.num_heads), ht.IntSymbol(self.head_dim)], name=f'reshape_k_{self.name}')
-        value = v.reshape([mbs_times_dp_symbol, seq_len_symbol, ht.IntSymbol(self.num_heads), ht.IntSymbol(self.head_dim)], name=f'reshape_v_{self.name}')
+        key = k.reshape([mbs_times_dp_symbol, seq_len_symbol, ht.IntSymbol(self.num_groups), ht.IntSymbol(self.head_dim)], name=f'reshape_k_{self.name}')
+        value = v.reshape([mbs_times_dp_symbol, seq_len_symbol, ht.IntSymbol(self.num_groups), ht.IntSymbol(self.head_dim)], name=f'reshape_v_{self.name}')
 
         # apply relative positional encoding (rotary embedding)
         def apply_rotary_pos_emb(x, _name='q'):
@@ -172,7 +175,15 @@ class ParallelMLP(ht.nn.Module):
         # [b*seq_len, h] -> [b*seq_len, 2* 2.7* h]
         intermediate_parallel = self.dense_h_to_4h(hidden_states)
         # fused kernel: x1*sigmoid(x1)*x2
-        intermediate_parallel = ht.swiglu(intermediate_parallel, name=f'swiglu_{self.name}')
+        with ht.recompute(multi_recompute = [
+            [False] if ds_parallel_config['recompute_granularity'] is None else
+            [
+                True if dp_recompute_granularity == 'selective' and self.layer_idx in recompute_layer_idxs else False
+                for dp_recompute_granularity, recompute_layer_idxs in zip(ds_parallel_config['recompute_granularity'], ds_parallel_config['recompute_layer_idxs_list'])
+            ]
+            for ds_parallel_config in self.ds_parallel_configs
+        ]):
+            intermediate_parallel = ht.swiglu(intermediate_parallel, name=f'swiglu_{self.name}')
 
         # [b*seq_len, 4h] -> [b*seq_len, h]
         output = self.dense_4h_to_h(intermediate_parallel)

--- a/hetu/core/stream.h
+++ b/hetu/core/stream.h
@@ -15,8 +15,7 @@ constexpr StreamIndex kD2HStream = 4;
 constexpr StreamIndex kP2PStream = 5;
 constexpr StreamIndex kCollectiveStream = 6;
 constexpr StreamIndex kSwitchCollectiveStream = 7;
-constexpr StreamIndex kOffloadStream = 8;
-constexpr StreamIndex kBridgeStream = 9;
+constexpr StreamIndex kBridgeStream = 8;
 constexpr StreamIndex kJoinStream = HT_NUM_STREAMS_PER_DEVICE - 1;
 
 using PackedStreamId = uint16_t;

--- a/hetu/graph/define_and_run_graph.cc
+++ b/hetu/graph/define_and_run_graph.cc
@@ -40,9 +40,8 @@ Operator& DefineAndRunGraph::MakeOpInner(std::shared_ptr<OpInterface> body,
                                          TensorList inputs, OpMeta op_meta) {
   _check_all_inputs_in_graph(inputs, op_meta.extra_deps);
   // for optimization passes
-  // TODO: support multi-strategies offload
   op_meta = op_meta.set_multi_recompute(Recompute::multi_recompute())
-                   .set_is_cpu_offload(ActivationCPUOffload::enabled());
+                   .set_multi_cpu_offload(ActivationCPUOffload::multi_cpu_offload());
   auto& op = MakeAndAddOp(std::move(body), std::move(inputs), std::move(op_meta));
   if (op->op_meta().need_dequantization()) {
     OpId param_id = op->op_meta().parameter_dict["tensor_id"];

--- a/hetu/graph/executable_graph.cc
+++ b/hetu/graph/executable_graph.cc
@@ -362,7 +362,7 @@ void ExecutableGraph::SubstituteCommOp(const OpRefList& topo_order) {
       auto& comm_op = op;
       // 获取其所在的subgraph使得后续替换的op都出现在同样的subgraph中
       // 有如下几种可能
-      // 1、在optimize-compute bridge或compute-oprimize bridge的subgraph中
+      // 1、在optimize-compute bridge或compute-optimize bridge的subgraph中
       // 例如zero与grad相关的(split)-all-gather/-all-reduce/-reduce-scatter或batched-send-recv
       // 2、在pipeline layer的subgraph中
       // 例如pp相关的(batched)-send-recv
@@ -1679,7 +1679,6 @@ NDArrayList ExecutableGraph::Run(const Tensor& loss, const TensorList& fetches,
       Instantiate(fetches, local_device);
       HT_LOG_DEBUG << local_device << ": [Execution Plan] Instantiate end...";
 
-      /*
       // init instantiated topo
       OpRefList topo_before_recompute = Graph::TopoSort(fetches, num_ops(), is_op_computed);
       HT_LOG_DEBUG << local_device << ": global topo before recompute pass: " << topo_before_recompute;
@@ -1701,8 +1700,7 @@ NDArrayList ExecutableGraph::Run(const Tensor& loss, const TensorList& fetches,
       Graph::push_graph_ctx(id());
       ActivationCPUOffload::OffloadToCPU(topo_before_activation_offload);
       Graph::pop_graph_ctx();
-      HT_LOG_INFO << local_device << ": [Execution Plan] activation offload pass end...";
-      */
+      HT_LOG_DEBUG << local_device << ": [Execution Plan] activation offload pass end...";
 
       // init topo contains comm_op
       OpRefList topo_before_substitute_comm = Graph::TopoSort(fetches, num_ops(), is_op_computed);

--- a/hetu/graph/offload/activation_cpu_offload.h
+++ b/hetu/graph/offload/activation_cpu_offload.h
@@ -10,16 +10,16 @@ namespace graph {
 
 class ActivationCPUOffload {
  public:
-  static bool enabled() {
-    return _enabled;
+  static const std::vector<std::vector<bool>>& multi_cpu_offload() {
+    return _multi_cpu_offload_stack.top();
   }
 
-  static void set_cpu_offload_enabled() {
-    _enabled = true;
+  static void push_cpu_offload_enabled(const std::vector<std::vector<bool>>& multi_cpu_offload) {
+    _multi_cpu_offload_stack.push(multi_cpu_offload);
   }
 
-  static void reset_cpu_offload_enabled() {
-    _enabled = false;
+  static void pop_cpu_offload_enabled() {
+    _multi_cpu_offload_stack.pop();
   }
 
   static void OffloadToCPU(const OpRefList& topo_order);
@@ -30,7 +30,7 @@ class ActivationCPUOffload {
 
   static void OffloadTensorToCPU(const OpRefList& topo_order, const Tensor& tensor);
 
-  static bool _enabled;
+  static std::stack<std::vector<std::vector<bool>>> _multi_cpu_offload_stack;
 };
 
 } // namespace graph

--- a/python/hetu/_binding/graph/cpu_offload.cc
+++ b/python/hetu/_binding/graph/cpu_offload.cc
@@ -10,14 +10,24 @@ namespace graph {
 
 PyObject* PyPushCPUOffloadCtx(PyObject*, PyObject* args, PyObject* kwargs) {
   HT_PY_FUNC_BEGIN
-  ActivationCPUOffload::set_cpu_offload_enabled();
+  static PyArgParser parser({
+    "push_cpu_offload_ctx(List[List[bool]] multi_cpu_offload)",
+  });
+  auto parsed_args = parser.parse(args, kwargs);
+  if (parsed_args.signature_index() == 0) {
+    ActivationCPUOffload::push_cpu_offload_enabled(parsed_args.get_bool_list_list(0));
+    Py_RETURN_NONE;
+  } else {
+    HT_PY_PARSER_INCORRECT_SIGNATURE(parsed_args);
+    __builtin_unreachable();
+  }
   Py_RETURN_NONE;
   HT_PY_FUNC_END
 }
 
 PyObject* PyPopCPUOffloadCtx(PyObject*, PyObject* args, PyObject* kwargs) {
   HT_PY_FUNC_BEGIN
-  ActivationCPUOffload::reset_cpu_offload_enabled();
+  ActivationCPUOffload::pop_cpu_offload_enabled();
   Py_RETURN_NONE;
   HT_PY_FUNC_END
 }

--- a/python/hetu/nn/modules/module.py
+++ b/python/hetu/nn/modules/module.py
@@ -323,20 +323,33 @@ class Module(object):
                 mutli_recompute = [[False]]  
                 print(f"Warning: {self.__class__.__name__} does not have ds_parallel_configs attribute, undefined behavior may happen")
                 
+            # multi-strategies of cpu offload
+            if self._cpu_offload:
+                mutli_cpu_offload = [[True] for _ in range(1 if self.ds_parallel_configs is None else len(self.ds_parallel_configs))]
+            elif self.ds_parallel_configs is not None:
+                mutli_cpu_offload = [[False] if 'cpu_offload' not in self.ds_parallel_configs[i] else self.ds_parallel_configs[i]['cpu_offload'] for i in range(len(self.ds_parallel_configs))]
+            else:
+                mutli_cpu_offload = [[False]]
+                print(f"Warning: {self.__class__.__name__} does not have ds_parallel_configs attribute, undefined behavior may happen")
+                
             # for name, child in self.named_children():
             #     print("Sub:", name, ",", child)
             # print(self.module_name, self.ds_parallel_configs)
-            # stack.enter_context(hetu.recompute(mutli_recompute))
-            # TODO: support multi-strategies 
-            # stack.enter_context(hetu.cpu_offload() if self._cpu_offload else nullcontext())
+            stack.enter_context(hetu.recompute(mutli_recompute))
+            stack.enter_context(hetu.cpu_offload(mutli_cpu_offload))
 
             # 实际forward
             value = self.forward(*input, **kwargs)
             
             # block之间显式地插入了comm op从而阻隔了连续的recompute
             # 之前需要在这里手动设置block的output不做recompute
-            # if isinstance(value, hetu.Tensor):
-            #     value._make_recompute([False for i in range(1 if self.ds_parallel_configs is None else len(self.ds_parallel_configs))])
+            
+            # 手动设置module的output不做recompute，从ds config传入
+            if isinstance(value, hetu.Tensor):
+                value._make_recompute(
+                    [False] if self.ds_parallel_configs is None else
+                    [ds_parallel_config.get('output_recompute', [False]) for ds_parallel_config in self.ds_parallel_configs]
+                )
             return value
     
     def forward(self, *input: Any, **kwargs: Any) -> Any:

--- a/python/hetu/nn/modules/parallel_utils.py
+++ b/python/hetu/nn/modules/parallel_utils.py
@@ -22,6 +22,23 @@ def get_multi_ds_parallel_config(ds_parallel_configs, module_name, _range=-1):
         f'ds_parallel_configs parse error, cannot find {module_name} with range id {_range}'   
     return multi_ds_parallel_config
 
+def get_multi_recompute_from(ds_parallel_configs, layer_idx):
+    multi_recompute_configs = []
+    for ds_parallel_config in ds_parallel_configs:
+        if ds_parallel_config['recompute_granularity'] is None:
+            multi_recompute_configs.append([False])
+        else:
+            dp_recompute_configs = []
+            for dp_recompute_granularity, recompute_layer_idxs in \
+                zip(ds_parallel_config['recompute_granularity'], \
+                    ds_parallel_config['recompute_layer_idxs_list']):
+                if dp_recompute_granularity == 'selective' and layer_idx in recompute_layer_idxs:
+                    dp_recompute_configs.append(True)
+                else:
+                    dp_recompute_configs.append(False)
+            multi_recompute_configs.append(dp_recompute_configs)
+    return multi_recompute_configs
+
 def parallel_data_provider(global_data, ds_union, device_group_index, device_index):
     ds = ds_union.get_local(device_group_index)
     order, states = ds.order, ds.states


### PR DESCRIPTION
## Motivation
This PR introduces the following improvements to the framework:

1. **Add recomputation granularity and method config**: Existing framework has supported multi-strategy recomputation, but we didn't add practical recomputation granularity and method configs like other frameworks such as Megatron-LM and NeMo. This PR fills this gap and add relevant docs. **One thing to note** is that, when Flash-Attention is enabled, the `selective` granularity will apply recomputation to SwiGLU and RMSNorm in Transformer blocks, with reference to [Megatron-kwai](https://www.usenix.org/conference/atc24/presentation/yuan).

2. **Support multi-strategy activation CPU offloading**: Existing framework does not support multi-strategy CPU offloading. This PR supports it and now we can add recomputation/offloading into ds_configs. However, practical offloading configs are not supported by now.

3. **Support MQA/GQA for Llama model**: Existing Llama model implementation only supports MHA, while GQA is widely adopted by Llama-2 and Llama-3 models. This PR fills this gap.

## Modifications

- Support more recompute granularities and methods
- Add recomputation docs
- Support multi-strategy activation CPU offloading
- Support GQA/MQA for Llama model

## Known Issues

- End-to-end testing was not attempted in this PR due to the notorious RPC compilation and installation. More tests are needed to verify the effectiveness of recomputation.